### PR TITLE
change from TEXT to LONGTEXT in the content table

### DIFF
--- a/backend/src/main/java/com/redmatrix/notesapp/entity/Note.java
+++ b/backend/src/main/java/com/redmatrix/notesapp/entity/Note.java
@@ -24,7 +24,7 @@ public class Note {
     @Column(nullable = false)
     private String title;
     
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "LONGTEXT")
     private String content;
     
     @Column(name = "owner_wallet")


### PR DESCRIPTION
modified the `content` table to accomodate longer string (as the image might be encoded to base64)